### PR TITLE
Make initNewTracer() mirror initGlobalTracer()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentracing",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "dist/opentracing-node-debug.js",
   "scripts": {
     "webpack": "npm run webpack-node-debug && npm run webpack-node-prod && npm run webpack-browser-debug && npm run webpack-browser-prod",

--- a/src/singleton.js
+++ b/src/singleton.js
@@ -16,25 +16,23 @@ export default class Singleton extends Tracer {
     }
 
     /**
-     * [initialize description]
-     * @return {[type]} [description]
+     * Set the global Tracer's underlying implementation.
+     *
+     * The behavior is undefined if this function is called more than once.
      */
     initGlobalTracer(tracingImp) {
         this._imp = tracingImp.newTracer();
     }
 
     /**
-     * Create a new Tracer object using the global implementation registered
-     * with initGlobalTracer. To reduce complexity, it is currently intentionally
-     * not possible to create a new Tracer with a different underlying
-     * implementation than the globally registered implementation.
+     * Create a new Tracer object with the given underlying implementation.
      *
-     * @return {[type]} [description]
+     * @return {Tracer} a new Tracer object
      */
-    initNewTracer() {
+    initNewTracer(tracingImp) {
         if (!this._imp) {
             return null;
         }
-        return this._imp.newTracer();
+        return new Tracer(tracingImp);
     }
 }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -12,8 +12,8 @@ export default class Tracer {
      * [constructor description]
      * @return {[type]} [description]
      */
-    constructor() {
-        this._imp = null;
+    constructor(imp) {
+        this._imp = imp || null;
     }
 
     /**


### PR DESCRIPTION
Changes the signature of `initNewTracer()` to take an tracer implementation object (rather than implicitly create a new one via the global tracer.  I believe this qualifies as a small, logical change as it makes two similar methods have similar signatures.

Note: the OpenTracing spec at this point specifies the `Tracer` interface but not how tracers are created / acquired; with that in mind, I believe this change fits with the standard.

(Also for what it's worth, the LightStep tracer allows multiple Tracer instances to be created, so this change was needed to support that functionality.)




