### PR TITLE
Run API conformance checks in debug only

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,0 @@
-'use strict';
-
-// TODO: make this into a webpack build option so that production builds do
-// not necessarily need to include the overhead of the argument checks.
-// For the initial iterations, default to this being enabled.
-export const API_CONFORMANCE_CHECKS = true;

--- a/src/span.js
+++ b/src/span.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import * as Constants from './constants';
 import TraceContext from './trace_context';
 
 /**
@@ -28,7 +27,7 @@ export default class Span {
     // ---------------------------------------------------------------------- //
 
     traceContext() {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length !== 0) {
                 throw new Error('Invalid arguments');
             }
@@ -46,7 +45,7 @@ export default class Span {
      * @return {[type]} [description]
      */
     setTag(key, value) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length !== 2) {
                 throw new Error('Invalid number of arguments');
             }
@@ -72,7 +71,7 @@ export default class Span {
      * @return {[type]}         [description]
      */
     info(message, payload) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length < 1 || arguments.length > 2) {
                 throw new Error('Invalid arguments.');
             }
@@ -94,7 +93,7 @@ export default class Span {
      * @return {[type]}         [description]
      */
     error(message, payload) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length < 1 || arguments.length > 2) {
                 throw new Error('Invalid arguments.');
             }
@@ -110,7 +109,7 @@ export default class Span {
     }
 
     startChild(operationName) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length !== 1) {
                 throw new Error('Invalid arguments');
             }
@@ -130,7 +129,7 @@ export default class Span {
      * [finish description]
      */
     finish() {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length !== 0) {
                 throw new Error('Invalid arguments');
             }

--- a/src/trace_context.js
+++ b/src/trace_context.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import * as Constants from './constants';
-
 const kKeyRegExp = new RegExp(/^[a-z0-9][-a-z0-9]*/);
 
 /**
@@ -26,7 +24,7 @@ export default class TraceContext {
      * @param {[type]} value [description]
      */
     setTraceAttribute(key, value) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length !== 2) {
                 throw new Error('Expected 2 arguments');
             }
@@ -58,7 +56,7 @@ export default class TraceContext {
      * @return {[type]}     [description]
      */
     traceAttribute(key) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length !== 1) {
                 throw new Error('Expected 1 arguments');
             }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import * as Constants from './constants';
 import Span from './span';
 
 /**
@@ -34,7 +33,7 @@ export default class Tracer {
      * @return {[type]}              [description]
      */
     encodeTraceContext(traceContext) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length  !== 1) {
                 throw new Error('Invalid arguments.');
             }
@@ -56,7 +55,7 @@ export default class Tracer {
      * @return {[type]}      [description]
      */
     decodeTraceContext(obj) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length  !== 1) {
                 throw new Error('Invalid arguments.');
             }
@@ -74,7 +73,7 @@ export default class Tracer {
      * @return {[type]} [description]
      */
     newRootTraceContext() {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length  !== 0) {
                 throw new Error('Invalid arguments.');
             }
@@ -92,7 +91,7 @@ export default class Tracer {
      * @return {[type]} [description]
      */
     newChildTraceContext(parentContext) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length  !== 1) {
                 throw new Error('Invalid arguments.');
             }
@@ -114,7 +113,7 @@ export default class Tracer {
      * @return {[type]}           [description]
      */
     startTrace(operationName) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length  !== 1) {
                 throw new Error('Invalid arguments.');
             }
@@ -140,7 +139,7 @@ export default class Tracer {
      * @return {[type]}               [description]
      */
     joinTrace(operationName, parentContext) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length  !== 2) {
                 throw new Error('Invalid arguments.');
             }
@@ -166,7 +165,7 @@ export default class Tracer {
      * @return {[type]}               [description]
      */
     startSpanWithContext(operationName, traceContext) {
-        if (Constants.API_CONFORMANCE_CHECKS) {
+        if (API_CONFORMANCE_CHECKS) {
             if (arguments.length  !== 2) {
                 throw new Error('Invalid arguments.');
             }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ var defines = {
     DEBUG            : false,
     PLATFORM_NODE    : false,
     PLATFORM_BROWSER : false,
+    API_CONFORMANCE_CHECKS : false,
 };
 
 var bundlePlatform = "";
@@ -21,6 +22,7 @@ var devtool = undefined;
 switch (CONFIG) {
     case "debug":
         defines.DEBUG = true;
+        defines.API_CONFORMANCE_CHECKS = true;
         bundleSuffix = "-debug";
         devtool = "source-map";
         break;


### PR DESCRIPTION
Ensure the `API_CONFORMANCE_CHECKS` code blocks (i.e. check number and type of arguments on each call) exist only in debug.

Specifically, modifies the `webpack.config.js` configuration to set `API_CONFORMANCE_CHECKS` as a constant that will be removed by dead-code elimination step of the UglifyJS plugin. Note: I manually verified in the generated production and debug code that the checks will be done only in debug builds.

Resolves https://github.com/opentracing/opentracing-javascript/issues/7.