### PR TITLE
Automate webpack to run as part of publish step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - 0.12

--- a/dist/.gitignore
+++ b/dist/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!.npmignore

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "opentracing",
-  "version": "0.9.5",
+  "version": "0.9.7",
   "main": "dist/opentracing-node-debug.js",
   "scripts": {
+    "prepublish": "npm run webpack",
+    "test": "node node_modules/mocha/bin/mocha -c test/unittest.js",
+
     "webpack": "npm run webpack-node-debug && npm run webpack-node-prod && npm run webpack-browser-debug && npm run webpack-browser-prod",
     "webpack-node-debug": "BUILD_PLATFORM=node BUILD_CONFIG=debug webpack --display-error-details",
     "webpack-node-prod": "BUILD_PLATFORM=node BUILD_CONFIG=prod webpack --display-error-details",
     "webpack-browser-debug": "BUILD_PLATFORM=browser BUILD_CONFIG=debug webpack --display-error-details",
-    "webpack-browser-prod": "BUILD_PLATFORM=browser BUILD_CONFIG=prod webpack --display-error-details",
-    "test": "node node_modules/mocha/bin/mocha -c test/unittest.js"
+    "webpack-browser-prod": "BUILD_PLATFORM=browser BUILD_CONFIG=prod webpack --display-error-details"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Automates the JavaScript compilation step (i.e. running `webpack`) when publishing the OpenTracing NPM package.

The two changes are:

1. Include an empty `.npmignore` in the `dist` directory so the published package *does not* ignore the files in the `dist` directory. The default behavior of NPM is to use the `.gitignore` file if there is no `.npmignore` file, but in this case, the files in the published package and the files in the source are *not* supposed to be the same.

2. Add a `prepublish` "script" step that runs the `webpack` step to do the build. The `prepublish` script is automatically invoked on publish so that building the source is no longer a manual step.