### PR TITLE
Sync to recent OpenTracing spec updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library is a JavaScript implementation of Open Tracing API. It is intended 
 
 ## Required Reading
 
-In order to fully understand this platform API, one must must first be familiar with the [OpenTracing project](http://opentracing.io) and
+To fully understand this platform API, it's helpful to be familiar with the [OpenTracing project](http://opentracing.io) and
 [terminology](http://opentracing.io/spec/) more generally.
 
 ## Quick Start
@@ -15,7 +15,7 @@ Install the package:
 npm install --save opentracing
 ```
 
-In the JS code, add instrumentation to the operations to be tracked. This is composed primarily of using "spans" around operations of interest and adding log statements to capture useful data relevant to those operations.
+In your JavaScript code, add instrumentation to the operations to be tracked. This is composed primarily of using "spans" around operations of interest and adding log statements to capture useful data relevant to those operations.
 
 ```js
 var http = require('http');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentracing",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "main": "dist/opentracing-node-debug.js",
   "scripts": {
     "prepublish": "npm run webpack",

--- a/src/carriers/binary_carrier.js
+++ b/src/carriers/binary_carrier.js
@@ -1,0 +1,8 @@
+'use strict';
+
+export default class BinaryCarrier {
+    constructor() {
+        this.tracerState = new Uint8Array();
+        this.baggage = new Uint8Array();
+    }
+}

--- a/src/carriers/split_text_carrier.js
+++ b/src/carriers/split_text_carrier.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/**
+ * A SplitTextCarrier is intended to hold string-string pairs in its two
+ * associative arrays.
+ */
+export default class SplitTextCarrier {
+    constructor() {
+        this.tracerState = {};
+        this.baggage = {};
+    }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,12 +2,12 @@
 
 module.exports = {
     /**
-     * Used to inject/join a span with a binary carrier.
+     * Used to inject/join a span with using a BinaryCarrier.
      */
     FORMAT_SPLIT_BINARY : 'split_binary',
 
     /**
-     * Used to inject/join a span with a text carrier.
+     * Used to inject/join a span with using a SplitTextCarrier.
      */
     FORMAT_SPLIT_TEXT   : 'split_text',
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+    /**
+     * Used to inject/join a span with a binary carrier.
+     */
+    FORMAT_SPLIT_BINARY : 'split_binary',
+
+    /**
+     * Used to inject/join a span with a text carrier.
+     */
+    FORMAT_SPLIT_TEXT   : 'split_text',
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,14 @@
 'use strict';
 
 import Singleton from './singleton';
+import * as Constants from './constants';
 
 let singleton =  new Singleton();
 
-// Add in constants to the singleton object
-singleton.FORMAT_SPLIT_BINARY = 'split_binary';
-singleton.FORMAT_SPLIT_TEXT   = 'split_text';
+// Merge the constants into the singleton object so they are accessible at the
+// package level.
+for (let key in Constants) {
+    singleton[key] = Constants[key];
+}
 
 module.exports = singleton;

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,5 @@
 'use strict';
 
 import Singleton from './singleton';
-import * as Constants from './constants';
 
-let singleton =  new Singleton();
-
-// Merge the constants into the singleton object so they are accessible at the
-// package level.
-for (let key in Constants) {
-    singleton[key] = Constants[key];
-}
-
-module.exports = singleton;
+module.exports = new Singleton();

--- a/src/singleton.js
+++ b/src/singleton.js
@@ -1,6 +1,9 @@
 'use strict';
 
 import Tracer from './tracer';
+import BinaryCarrier from './carriers/binary_carrier';
+import SplitTextCarrier from './carriers/split_text_carrier';
+import * as Constants from './constants';
 
 /**
  * The Singleton object extends the standard Tracer object so that the default
@@ -39,9 +42,23 @@ export default class Singleton extends Tracer {
      * Creates the Singleton with no underlying implementation (i.e. defaults
      * to no-op behavior for all functions).
      *
+     * The OpenTracing package-level object acts both at the singleton and the
+     * package interface itself, so this Singleton is both a the Tracer and
+     * also includes all the global library symbols.
+     *
      * Note: this should never be called directly by consumers of the library.
      */
     constructor() {
         super();
+
+        // Merge the constants into the singleton object so they are accessible at the
+        // package level.
+        for (let key in Constants) {
+            this[key] = Constants[key];
+        }
+
+        // Include the carriers objects
+        this.SplitTextCarrier = SplitTextCarrier;
+        this.BinaryCarrier = BinaryCarrier;
     }
 }

--- a/src/span.js
+++ b/src/span.js
@@ -14,6 +14,20 @@ export default class Span {
     // OpenTracing API methods
     // ---------------------------------------------------------------------- //
 
+    setOperationName(name) {
+        if (API_CONFORMANCE_CHECKS) {
+            if (arguments.length !== 1) {
+                throw new Error('Invalid number of arguments');
+            }
+            if (typeof name !== 'string' || name.length > 0) {
+                throw new Error('Name must be a string of length > 0');
+            }
+        }
+        if (this._imp) {
+            this._imp.setOperationName(name);
+        }
+        return this;
+    }
 
     /**
      * Adds a single tag to the span.  See `AddTags()` for details.
@@ -31,6 +45,7 @@ export default class Span {
             }
         }
         this.addTags({ [key] : value });
+        return this;
     }
 
     /**
@@ -63,27 +78,27 @@ export default class Span {
             return;
         }
         this._imp.addTags(keyValuePairs);
+        return this;
     }
 
     /**
      * Set an arbitrary key-value string pair that will be carried along the
      * full path of a trace.
      *
-     * All spans created as children of this span will inherit the set of trace
-     * attributes of this span.
+     * All spans created as children of this span will inherit the baggage items
+     * of this span.
      *
-     * Trace attributes are copied between all spans, both in-process and across
-     * distributed requets, therefore this feature should be used with care to
+     * Baggage items are copied between all spans, both in-process and across
+     * distributed requests, therefore this feature should be used with care to
      * ensure undue overhead is not incurred.
      *
-     * Trace keys are case insensitive, must match the regular expresssion
+     * Keys are case insensitive and must match the regular expresssion
      * `[a-z0-9][-a-z0-9]*`.
      *
      * @param {string} key
      * @param {string} value
      */
-    setTraceAttribute(key, value) {
-
+    setBaggageItem(key, value) {
         if (API_CONFORMANCE_CHECKS) {
             if (arguments.length !== 2) {
                 throw new Error('Expected 2 arguments');
@@ -107,11 +122,11 @@ export default class Span {
         if (this._imp) {
             this._imp.setTraceAttribute(key, value);
         }
-        return;
+        return this;
     }
 
     /**
-     * Returns the value for the given trace attribute key.
+     * Returns the value for the given baggage item key.
      *
      * @param  {string} key
      *         The key for the given trace attribute.
@@ -119,7 +134,7 @@ export default class Span {
      *         String value for the given key, or undefined if the key does not
      *         correspond to a set trace attribute.
      */
-    getTraceAttribute(key) {
+    getBaggageItem(key) {
         if (API_CONFORMANCE_CHECKS) {
             if (arguments.length !== 1) {
                 throw new Error('Expected 1 arguments');
@@ -206,6 +221,7 @@ export default class Span {
             return;
         }
         this._imp.log(fields);
+        return this;
     }
 
     /**

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,6 +1,9 @@
 'use strict';
 
 import Span from './span';
+import Constants from './constants';
+import SplitTextCarrier from './carriers/split_text_carrier';
+import BinaryCarrier from './carriers/binary_carrier';
 
 /**
  * Tracer is the entry-point between the instrumentation API and the tracing
@@ -97,6 +100,12 @@ export default class Tracer {
             if (typeof format !== 'string') {
                 throw new Error('format expected to be a string');
             }
+            if (format === Constants.FORMAT_SPLIT_TEXT && !(carrier instanceof SplitTextCarrier)) {
+                throw new Error('Unexpected carrier object for "split_text" format');
+            }
+            if (format === Constants.FORMAT_BINARY && !(carrier instanceof BinaryCarrier)) {
+                throw new Error('Unexpected carrier object for "binary" format');
+            }
         }
 
         let imp = null;
@@ -108,7 +117,7 @@ export default class Tracer {
     /**
      * Returns a new Span object with the given operation name using the trace
      * information from the carrier.
-     * 
+     *
      * @param  {string} operationName
      *         Operation name to use on the newly created span.
      * @param  {string} format
@@ -127,6 +136,12 @@ export default class Tracer {
             }
             if (typeof format !== 'string' || !format.length) {
                 throw new Error('format is expected to be a string of non-zero length');
+            }
+            if (format === Constants.FORMAT_SPLIT_TEXT && !(carrier instanceof SplitTextCarrier)) {
+                throw new Error('Unexpected carrier object for "split_text" format');
+            }
+            if (format === Constants.FORMAT_BINARY && !(carrier instanceof BinaryCarrier)) {
+                throw new Error('Unexpected carrier object for "binary" format');
             }
         }
         let spanImp = null;

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -76,16 +76,23 @@ export default class Tracer {
     }
 
     /**
-     * Returns an Injector object that handles the given `format`.
+     * Injects the information about the given span into the carrier
+     * so that the span can propogate across inter-process barriers.
      *
+     * @param  {Span} span
+     *         The span whose information should be injected into the carrier.
      * @param  {string} format
-     *         See the Injector documentation for valid formats.
-     * @return {Injector}
+     *         The format of the carrier.
+     * @param  {any} carrier
+     *         The type of the carrier object is determined by the format.
      */
-    injector(format) {
+    inject(span, format, carrier) {
         if (API_CONFORMANCE_CHECKS) {
-            if (arguments.length !== 1) {
+            if (arguments.length !== 3) {
                 throw new Error('Invalid number of arguments.');
+            }
+            if (!(span instanceof Span)) {
+                throw new Error('Expected span object as first argument');
             }
             if (typeof format !== 'string') {
                 throw new Error('format expected to be a string');
@@ -94,32 +101,39 @@ export default class Tracer {
 
         let imp = null;
         if (this._imp) {
-            imp = this._imp.injector(format);
+            imp = this._imp.inject(span, format, carrier);
         }
-        return new Injector(imp);
     }
 
     /**
-     * Returns an Extractor object that handles the given `format`.
-     *
+     * Returns a new Span object with the given operation name using the trace
+     * information from the carrier.
+     * 
+     * @param  {string} operationName
+     *         Operation name to use on the newly created span.
      * @param  {string} format
-     *         See the Extractor documentation for valid formats.
-     * @return {Injector}
+     *         The format of the carrier.
+     * @param  {any} carrier
+     *         The type of the carrier object is determined by the format.
+     * @return {Span}
      */
-    extractor(format) {
+    join(operationName, format, carrier) {
         if (API_CONFORMANCE_CHECKS) {
-            if (arguments.length !== 1) {
+            if (arguments.length !== 3) {
                 throw new Error('Invalid number of arguments.');
             }
-            if (typeof format !== 'string') {
-                throw new Error('format expected to be a string');
+            if (typeof operationName !== 'string' || !operationName.length) {
+                throw new Error('operationName is expected to be a string of non-zero length');
+            }
+            if (typeof format !== 'string' || !format.length) {
+                throw new Error('format is expected to be a string of non-zero length');
             }
         }
-        let imp = null;
+        let spanImp = null;
         if (this._imp) {
-            imp = this._imp.extractor(format);
+            spanImp = this._imp.join(operationName, format, carrier);
         }
-        return new Extractor(imp);
+        return new Span(spanImp);
     }
 
     /**
@@ -139,7 +153,6 @@ export default class Tracer {
                 throw new Error('callback expected to be a function');
             }
         }
-
         if (!this._imp) {
             done(null);
             return;

--- a/test/unittest.js
+++ b/test/unittest.js
@@ -20,20 +20,24 @@ describe('OpenTracing API', function() {
                 expect(Tracer.initNewTracer).to.be.a('function');
             });
 
+            it('should have the required constants', function() {
+                expect(Tracer.FORMAT_SPLIT_TEXT).to.be.a('string');
+                expect(Tracer.FORMAT_SPLIT_BINARY).to.be.a('string');
+            });
+
             it('should have the required Tracer functions', function() {
                 expect(Tracer.startSpan).to.be.a('function');
-                expect(Tracer.injector).to.be.a('function');
-                expect(Tracer.extractor).to.be.a('function');
+                expect(Tracer.inject).to.be.a('function');
+                expect(Tracer.join).to.be.a('function');
                 expect(Tracer.flush).to.be.a('function');
             });
 
             it('should have the required Span functions', function() {
                 var span = Tracer.startSpan('test_operation');
-
                 expect(span.setTag).to.be.a('function');
                 expect(span.addTags).to.be.a('function');
-                expect(span.setTraceAttribute).to.be.a('function');
-                expect(span.getTraceAttribute).to.be.a('function');
+                expect(span.setBaggageItem).to.be.a('function');
+                expect(span.getBaggageItem).to.be.a('function');
                 expect(span.startChildSpan).to.be.a('function');
                 expect(span.log).to.be.a('function');
                 expect(span.logEvent).to.be.a('function');


### PR DESCRIPTION
Gets the JavaScript code in sync with some of the more recent OpenTracing spec updates:

- Renames the `set/getTraceAttribute` APIs to `set/getBaggageItem`
- Adds the binary and split text carriers and `inject`/`join` APIs to `Tracer`
- Adds `setOperationName` to `Span` (not new to the spec, but was not in the JS code before)
- Return the `this` object by default on most `Span` methods without an explicit return value in case users want to chain calls (and more specifically, since that's the pattern Python seems to be doing and keeping the platform APIs similar seems like a good thing)

  ​
