### PR TITLE
Fix FORMAT_SPLIT_BINARY

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentracing",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "main": "dist/opentracing-node.js",
   "scripts": {
     "prepublish": "npm run webpack",

--- a/src/span.js
+++ b/src/span.js
@@ -131,7 +131,7 @@ export default class Span {
             if (typeof key !== 'string' || key.length === 0) {
                 throw new Error('Key must be a string');
             }
-            if (!kKeyRegExp.match(key)) {
+            if (!kKeyRegExp.test(key)) {
                 throw new Error('Invalid trace key');
             }
 
@@ -167,7 +167,7 @@ export default class Span {
             if (typeof key !== 'string' || key.length === 0) {
                 throw new Error('Key must be a string');
             }
-            if (!kKeyRegExp.match(key)) {
+            if (!kKeyRegExp.test(key)) {
                 throw new Error('Invalid trace key');
             }
         }

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -107,13 +107,13 @@ export default class Tracer {
                 throw new Error('Expected span object as first argument');
             }
             if (typeof format !== 'string') {
-                throw new Error('format expected to be a string');
+                throw new Error('format expected to be a string. Found: ' + typeof format);
             }
             if (format === Constants.FORMAT_SPLIT_TEXT && !(carrier instanceof SplitTextCarrier)) {
                 throw new Error('Unexpected carrier object for "split_text" format');
             }
-            if (format === Constants.FORMAT_BINARY && !(carrier instanceof BinaryCarrier)) {
-                throw new Error('Unexpected carrier object for "binary" format');
+            if (format === Constants.FORMAT_SPLIT_BINARY && !(carrier instanceof BinaryCarrier)) {
+                throw new Error('Unexpected carrier object for "split_binary" format');
             }
         }
 
@@ -148,8 +148,8 @@ export default class Tracer {
             if (format === Constants.FORMAT_SPLIT_TEXT && !(carrier instanceof SplitTextCarrier)) {
                 throw new Error('Unexpected carrier object for "split_text" format');
             }
-            if (format === Constants.FORMAT_BINARY && !(carrier instanceof BinaryCarrier)) {
-                throw new Error('Unexpected carrier object for "binary" format');
+            if (format === Constants.FORMAT_SPLIT_BINARY && !(carrier instanceof BinaryCarrier)) {
+                throw new Error('Unexpected carrier object for "split_binary" format');
             }
         }
         let spanImp = null;


### PR DESCRIPTION
Two more small changes after further testing:

* Fix a few places where `FORMAT_BINARY` was written instead of `FORMAT_SPLIT_BINARY`
* Use `RegExp.test()` not `RegExp.match()`