### PR TITLE
Remove double Tracer implementation initialization

### DIFF
--- a/src/singleton.js
+++ b/src/singleton.js
@@ -20,9 +20,11 @@ export default class Singleton extends Tracer {
      * Set the global Tracer's underlying implementation.
      *
      * The behavior is undefined if this function is called more than once.
+     *
+     * @param {TracerImp} The Tracer implementation object
      */
-    initGlobalTracer(tracingImp) {
-        this._imp = tracingImp.newTracer();
+    initGlobalTracer(tracerImp) {
+        this._imp = tracerImp;
     }
 
     /**
@@ -30,8 +32,8 @@ export default class Singleton extends Tracer {
      *
      * @return {Tracer} a new Tracer object
      */
-    initNewTracer(tracingImp) {
-        return new Tracer(tracingImp);
+    initNewTracer(tracerImp) {
+        return new Tracer(tracerImp);
     }
 
     // ---------------------------------------------------------------------- //

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,7 +67,7 @@ switch (PLATFORM) {
         bundleSuffix = (CONFIG == 'debug') ? '' : '.min';
         defines.PLATFORM_BROWSER = true;
         target = "web";
-        libraryTarget = "var";
+        libraryTarget = "umd";
         break;
 
     default:


### PR DESCRIPTION
## Summary

Removes an accidental "double initialization" when setting the global tracer. Rather than using the passed-in object directly, it was cloning the passed in object via a call to `newTracer`.  This "worked" so wasn't noticed before, but is obviously inefficient!

Also, this changes the webpack config to use "umd" format (rather than "var" format) for the browser for broader compatibility.  The "var" format makes assumptions about accessibility of global variables that may not be true in different JS module systems.


