### PR TITLE
Update FORMAT_BINARY carrier format

### DIFF
--- a/src/binary_carrier.js
+++ b/src/binary_carrier.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Convenience class to use as a binary carrier.
+ *
+ * Any valid Object with a field named `buffer` may be used as a binary carrier;
+ * this class is only one such type of object that can be used.
+ */
+export default class BinaryCarrier {
+    constructor(binaryData) {
+        this.buffer = binaryData;
+    }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,10 @@
 
 module.exports = {
     /**
-     * Used to inject/join a span using a ArrayBuffer as a carrier.
+     * Used to inject/join a span using a binary format.
+     *
+     * A valid binary carrier is any Object with a field named 'buffer' that
+     * contains or will contain the binary data.
      */
     FORMAT_BINARY : 'binary',
 
@@ -12,7 +15,7 @@ module.exports = {
      * NOTE: Since HTTP headers are a particularly important use case for the
      * TEXT_MAP carrier, map keys identify their respective values in a
      * case-insensitive manner.
-     * 
+     *
      * NOTE: The TEXT_MAP carrier map may contain unrelated data (e.g.,
      * arbitrary HTTP headers). As such, the Tracer implementation should use a
      * prefix or other convention to distinguish Tracer-specific key:value

--- a/src/singleton.js
+++ b/src/singleton.js
@@ -2,6 +2,7 @@
 
 import Tracer from './tracer';
 import * as Constants from './constants';
+import BinaryCarrier from './binary_carrier';
 
 /**
  * The Singleton object extends the standard Tracer object so that the default
@@ -56,5 +57,8 @@ export default class Singleton extends Tracer {
         for (let key in Constants) {
             this[key] = Constants[key];
         }
+
+        // Carrier objects to be exposed at the package level
+        this.BinaryCarrier = BinaryCarrier;
     }
 }

--- a/test/unittest.js
+++ b/test/unittest.js
@@ -45,17 +45,24 @@ describe('OpenTracing API', function() {
             });
 
             it('should enforce the required carrier types', function() {
-                var textCarrier = {};
-                var binCarrier = new ArrayBuffer();
                 var span = Tracer.startSpan('test_operation');
 
-                // Pair format/carrier correctly:
+                var textCarrier = {};
                 expect(function() { Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, textCarrier); }).to.not.throw(Error);
-                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, binCarrier); }).to.not.throw(Error);
-
-                // Pair format/carrier incorrectly:
+                expect(function() { Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, ''); }).to.throw(Error);
                 expect(function() { Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, 5); }).to.throw(Error);
-                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, textCarrier); }).to.throw(Error);
+
+                var binCarrier = new Tracer.BinaryCarrier();
+                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, binCarrier); }).to.not.throw(Error);
+                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, new Object); }).to.not.throw(Error);
+                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, {}); }).to.not.throw(Error);
+                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, { buffer : null }); }).to.not.throw(Error);
+
+                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, binCarrier); }).to.not.throw(Error);
+                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, {}); }).to.not.throw(Error);
+                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, { buffer : null }); }).to.not.throw(Error);
+                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, { buffer : '' }); }).to.throw(Error);
+                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, { buffer : 5 }); }).to.throw(Error);
             });
         });
     });


### PR DESCRIPTION
## Summary

Resolves https://github.com/opentracing/opentracing-javascript/issues/22 by updating the semantics of the `carrier` for `FORMAT_BINARY`.

In short, `carrier` was previously specified as being an `ArrayBuffer` - but in JavaScript those are fixed length buffers, which creates some usage complications.  The specification is now "loosened" to be any valid object with a `buffer` field - which in turn can any array-like type (e.g. ArrayBuffer, Array, Uint8Array, Float32Array, etc.)