### PR TITLE
Handle the case of <script> and webpack

### DIFF
--- a/src/default_tracer.js
+++ b/src/default_tracer.js
@@ -6,12 +6,15 @@ import Singleton from './singleton';
 // tags vs included via webpack), it's possible for a single application to
 // have multiple copies of the OpenTracing code.  Try to ensure there's only one
 // singleton even in such scenarios.
-var singleton;
-if (typeof window !== 'undefined' && window.__opentracing_singleton) {
-    singleton = window.__opentracing_singleton;
-} else if (typeof global !== 'undefined' && global.__opentracing_singleton) {
-    singleton = global.__opentracing_singleton;
-} else {
+let handleWindow = (typeof window !== 'undefined') ? window : {};
+let handleGlobal = (typeof global !== 'undefined') ? global : {};
+
+let singleton = handleWindow.__opentracing_singleton ||
+    handleGlobal.__opentracing_singleton;
+if (!singleton) {
     singleton = new Singleton();
+    handleWindow.__opentracing_singleton = singleton;
+    handleGlobal.__opentracing_singleton = singleton;
 }
+
 module.exports = singleton;


### PR DESCRIPTION
## Summary

Fixes a defect where the singleton was not properly shared when the library consumer was including OpenTracing, for example, both via a `<script>` tag and an implicit copy via webpack or browserify.

The code simply incorrect before as it never set the shared singleton value.