### PR TITLE
Add conditionals to allow a null implementation object

### DIFF
--- a/src/singleton.js
+++ b/src/singleton.js
@@ -27,7 +27,9 @@ export default class Singleton extends Tracer {
 
         // Provide the implementation with a handle to the interface. This can
         // also be used a post-initialization signal.
-        tracerImp.setInterface(this);
+        if (tracerImp) {
+            tracerImp.setInterface(this);
+        }
     }
 
     /**
@@ -37,7 +39,9 @@ export default class Singleton extends Tracer {
      */
     initNewTracer(tracerImp) {
         let tracer = new Tracer(tracerImp);
-        tracerImp.setInterface(this);
+        if (tracerImp) {
+            tracerImp.setInterface(this);
+        }
         return tracer;
     }
 

--- a/test/unittest.js
+++ b/test/unittest.js
@@ -14,68 +14,80 @@ describe('OpenTracing API', function() {
     // Test that the API layer, while in debug mode, catches API misuse
     // before the implementation is even invoked (i.e. even with the no-op
     // implementation).
-    describe('Base layer conformance', function() {
 
-        describe('API surface area', function() {
-            it('should have the required functions on the singleton', function() {
-                expect(Tracer.initGlobalTracer).to.be.a('function');
-                expect(Tracer.initNewTracer).to.be.a('function');
-            });
-
-            it('should have the required constants', function() {
-                expect(Tracer.FORMAT_TEXT_MAP).to.be.a('string');
-                expect(Tracer.FORMAT_BINARY).to.be.a('string');
-            });
-
-            it('should have the required Tracer functions', function() {
-                expect(Tracer.startSpan).to.be.a('function');
-                expect(Tracer.inject).to.be.a('function');
-                expect(Tracer.join).to.be.a('function');
-                expect(Tracer.flush).to.be.a('function');
-            });
-
-            it('should have the required Span functions', function() {
-                var span = Tracer.startSpan('test_operation');
-                expect(span.tracer).to.be.a('function');
-                expect(span.setTag).to.be.a('function');
-                expect(span.addTags).to.be.a('function');
-                expect(span.setBaggageItem).to.be.a('function');
-                expect(span.getBaggageItem).to.be.a('function');
-                expect(span.log).to.be.a('function');
-                expect(span.logEvent).to.be.a('function');
-                expect(span.finish).to.be.a('function');
-            });
-
-            it('should enforce the required carrier types', function() {
-                var span = Tracer.startSpan('test_operation');
-
-                var textCarrier = {};
-                expect(function() { Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, textCarrier); }).to.not.throw(Error);
-                expect(function() { Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, ''); }).to.throw(Error);
-                expect(function() { Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, 5); }).to.throw(Error);
-
-                var binCarrier = new Tracer.BinaryCarrier();
-                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, binCarrier); }).to.not.throw(Error);
-                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, new Object); }).to.not.throw(Error);
-                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, {}); }).to.not.throw(Error);
-                expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, { buffer : null }); }).to.not.throw(Error);
-
-                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, binCarrier); }).to.not.throw(Error);
-                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, {}); }).to.not.throw(Error);
-                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, { buffer : null }); }).to.not.throw(Error);
-                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, { buffer : '' }); }).to.throw(Error);
-                expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, { buffer : 5 }); }).to.throw(Error);
-            });
+    describe('API surface area', function() {
+        it('should have the required functions on the singleton', function() {
+            expect(Tracer.initGlobalTracer).to.be.a('function');
+            expect(Tracer.initNewTracer).to.be.a('function');
         });
 
-        describe('Miscellaneous', function() {
-            before(function() {
-                NoopTracerImp = require('../src/imp/noop_imp.js');
-            });
+        it('should have the required constants', function() {
+            expect(Tracer.FORMAT_TEXT_MAP).to.be.a('string');
+            expect(Tracer.FORMAT_BINARY).to.be.a('string');
+        });
 
-            it('should not report leaks after setting the global tracer', function() {
-                Tracer.initGlobalTracer(new NoopTracerImp());
-            });
+        it('should have the required Tracer functions', function() {
+            expect(Tracer.startSpan).to.be.a('function');
+            expect(Tracer.inject).to.be.a('function');
+            expect(Tracer.join).to.be.a('function');
+            expect(Tracer.flush).to.be.a('function');
+        });
+
+        it('should have the required Span functions', function() {
+            var span = Tracer.startSpan('test_operation');
+            expect(span.tracer).to.be.a('function');
+            expect(span.setTag).to.be.a('function');
+            expect(span.addTags).to.be.a('function');
+            expect(span.setBaggageItem).to.be.a('function');
+            expect(span.getBaggageItem).to.be.a('function');
+            expect(span.log).to.be.a('function');
+            expect(span.logEvent).to.be.a('function');
+            expect(span.finish).to.be.a('function');
+        });
+
+        it('should enforce the required carrier types', function() {
+            var span = Tracer.startSpan('test_operation');
+
+            var textCarrier = {};
+            expect(function() { Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, textCarrier); }).to.not.throw(Error);
+            expect(function() { Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, ''); }).to.throw(Error);
+            expect(function() { Tracer.inject(span, Tracer.FORMAT_TEXT_MAP, 5); }).to.throw(Error);
+
+            var binCarrier = new Tracer.BinaryCarrier();
+            expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, binCarrier); }).to.not.throw(Error);
+            expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, new Object); }).to.not.throw(Error);
+            expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, {}); }).to.not.throw(Error);
+            expect(function() { Tracer.inject(span, Tracer.FORMAT_BINARY, { buffer : null }); }).to.not.throw(Error);
+
+            expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, binCarrier); }).to.not.throw(Error);
+            expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, {}); }).to.not.throw(Error);
+            expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, { buffer : null }); }).to.not.throw(Error);
+            expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, { buffer : '' }); }).to.throw(Error);
+            expect(function() { Tracer.join('test_op2', Tracer.FORMAT_BINARY, { buffer : 5 }); }).to.throw(Error);
+        });
+    });
+
+    describe('No-op tracer', function() {
+        it('should return a valid no-op tracer object when given a null implemenation', function() {
+            var tracer;
+            expect(function() {
+                tracer = Tracer.initNewTracer(null);
+            }).not.to.throw();
+            expect(tracer).to.be.an('object');
+
+            var span = tracer.startSpan('test_span')
+            expect(span).to.be.an('object');
+            span.finish();
+        });
+    });
+
+    describe('Memory usage', function() {
+        before(function() {
+            NoopTracerImp = require('../src/imp/noop_imp.js');
+        });
+
+        it('should not report leaks after setting the global tracer', function() {
+            Tracer.initGlobalTracer(new NoopTracerImp());
         });
     });
 });


### PR DESCRIPTION
## Summary

Allow `let tracer = OpenTracing.initNewTracer(null)` to be a valid way to get a no-op tracer instance.

* Fix a defect where the code assumed a non-null value for e tracer
* Add a unit test to ensure passing null creates a valid no-op tracer

Note: the majority of the diffs are cosmetic indentation changes to the unit tests.