### PR TITLE
Roll back eslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chai": "^3.4.1",
     "clone": "^1.0.2",
     "colors": "^1.1.2",
-    "eslint": "^3.0.1",
+    "eslint": "2.13.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.10.2",
     "eslint-plugin-jsx-a11y": "^1.5.5",


### PR DESCRIPTION
Fixes #36 . 

**TL;DR**: roll back the version of eslint to 2.13.1 to avoid the version mismatch complaints (and since no eslint 3.x features are needed)

The TravisCI builds were failing due to a version requirement of the eslint base config (`eslint-config-airbnb`). This is a bit of a false negative since newer version of eslint works with the base config. In any case, this all seems to be related to https://github.com/airbnb/javascript/issues/936, which is currently still open.