### PR TITLE
Use the referee nomenclature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+0.10.3 (2016-06-12)
+-------------------
+
+- Use the `referee` terminology within `Reference`
+
+
 0.10.2 (2016-06-12)
 -------------------
 

--- a/src/reference.js
+++ b/src/reference.js
@@ -23,8 +23,8 @@ export default class Reference {
      * @return {SpanContext} The SpanContext being referred to (e.g., the
      *         parent in a REFERENCE_CHILD_OF Reference).
      */
-    spanContext() {
-        return this._spanContext;
+    referee() {
+        return this._referee;
     }
 
     /**
@@ -32,20 +32,20 @@ export default class Reference {
      *
      * @param {string} type - the Reference type constant (e.g.,
      *        REFERENCE_CHILD_OF or REFERENCE_FOLLOWS_FROM).
-     * @param {SpanContext} spanContext - the SpanContext being referred to. As
+     * @param {SpanContext} referee - the SpanContext being referred to. As
      *        a convenience, a Span instance may be passed in instead (in which
      *        case its .context() is used here).
      */
-    constructor(type, spanContext) {
+    constructor(type, referee) {
         if (API_CONFORMANCE_CHECKS) {
-            if (!(spanContext instanceof SpanContext || spanContext instanceof Span)) {
-                throw new Error('spanContext must be a Span or SpanContext instance');
+            if (!(referee instanceof SpanContext || referee instanceof Span)) {
+                throw new Error('referee must be a Span or SpanContext instance');
             }
         }
         this._type = type;
-        this._spanContext = (
-                spanContext instanceof Span ?
-                spanContext.context() :
-                spanContext);
+        this._referee = (
+                referee instanceof Span ?
+                referee.context() :
+                referee);
     }
 }


### PR DESCRIPTION
(Consistent with Go and this morning's https://github.com/opentracing/opentracing-python/commit/924093dc8da36e6e8ae63ac9bd9f41c523e21e64#diff-a1898244c8c6ea29725a1d5333973b9aR130)