### PR TITLE
Add the missing childOf method to Tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ This release makes the `opentracing-javascript` package conformant with the idea
 
 TL;DR, to start a child span, do this:
 
-```
+```javascript
 let parentSpan = ...;
 let childSpan = Tracer.startSpan('child op', { childOf : parentSpan });
 ```
 
 ... and to continue a trace from the server side of an RPC, do this:
 
-```
+```javascript
 let format = ...;  // same as for Tracer.join()
 let carrier = ...;  // same as for Tracer.join()
 let extractedCtx = Tracer.extract(format, carrier);

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -3,6 +3,7 @@
 import Span from './span';
 import SpanContext from './span_context';
 import Constants from './constants';
+import Reference from './reference';
 
 /**
  * Tracer is the entry-point between the instrumentation API and the tracing
@@ -106,11 +107,7 @@ export default class Tracer {
             // Convert fields.childOf to fields.references as needed.
             if (fields.childOf) {
                 // Convert from a Span or a SpanContext into a Reference.
-                let childOf = this.childOf(
-                        fields.childOf instanceof Span ?
-                        fields.childOf.context() :
-                        fields.childOf);
-
+                let childOf = this.childOf(fields.childOf);
                 if (fields.references) {
                     fields.references.push(childOf);
                 } else {
@@ -121,6 +118,16 @@ export default class Tracer {
             spanImp = this._imp.startSpan(fields);
         }
         return new Span(spanImp);
+    }
+
+    /**
+     * Returns a new CHILD_OF Reference to the given Span or SpanContext object.
+     *
+     * @param {object} spanOrSpanContext - the Span or SpanContext to reference
+     * @return {Reference}
+     */
+    childOf(spanOrSpanContext) {
+        return new Reference(Constants.REFERENCE_CHILD_OF, spanOrSpanContext);
     }
 
     /**


### PR DESCRIPTION
Adds the missing `childOf` method to Tracer. This was introduced in the transition to the `SpanContext`-based API.