### PR TITLE
Move followsFrom from Singleton to Tracer.

### DIFF
--- a/src/singleton.js
+++ b/src/singleton.js
@@ -47,28 +47,6 @@ export default class Singleton extends Tracer {
         return tracer;
     }
 
-    /**
-     * Return a new REFERENCE_CHILD_OF reference.
-     *
-     * @param {SpanContext} spanContext - the parent SpanContext instance to
-     *        reference.
-     * @return a REFERENCE_CHILD_OF reference pointing to `spanContext`
-     */
-    childOf(spanContext) {
-        return new Reference(Constants.REFERENCE_CHILD_OF, spanContext);
-    }
-
-    /**
-     * Return a new REFERENCE_FOLLOWS_FROM reference.
-     *
-     * @param {SpanContext} spanContext - the parent SpanContext instance to
-     *        reference.
-     * @return a REFERENCE_FOLLOWS_FROM reference pointing to `spanContext`
-     */
-    followsFrom(spanContext) {
-        return new Reference(Constants.REFERENCE_FOLLOWS_FROM, spanContext);
-    }
-
     // ---------------------------------------------------------------------- //
     // Private and non-standard methods
     // ---------------------------------------------------------------------- //

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -121,13 +121,25 @@ export default class Tracer {
     }
 
     /**
-     * Returns a new CHILD_OF Reference to the given Span or SpanContext object.
+     * Return a new REFERENCE_CHILD_OF reference.
      *
-     * @param {object} spanOrSpanContext - the Span or SpanContext to reference
-     * @return {Reference}
+     * @param {SpanContext} spanContext - the parent SpanContext instance to
+     *        reference.
+     * @return a REFERENCE_CHILD_OF reference pointing to `spanContext`
      */
-    childOf(spanOrSpanContext) {
-        return new Reference(Constants.REFERENCE_CHILD_OF, spanOrSpanContext);
+    childOf(spanContext) {
+        return new Reference(Constants.REFERENCE_CHILD_OF, spanContext);
+    }
+
+    /**
+     * Return a new REFERENCE_FOLLOWS_FROM reference.
+     *
+     * @param {SpanContext} spanContext - the parent SpanContext instance to
+     *        reference.
+     * @return a REFERENCE_FOLLOWS_FROM reference pointing to `spanContext`
+     */
+    followsFrom(spanContext) {
+        return new Reference(Constants.REFERENCE_FOLLOWS_FROM, spanContext);
     }
 
     /**


### PR DESCRIPTION
Moves `followsFrom` from `Singleton` to `Tracer`.

A bit more detail: I was a bit hasty in addressing the the missing method in the last PR. The `followsFrom` method also needs to be moved. In the case of a single global tracer, having `childOf` and `followsFrom` on the `Singleton` object works, but it does not work for the cases of multiple `Tracer` objects (since they're not methods of `Tracer` and `Tracer.startSpan` refers to them as instance methods). The only methods `Singleton` should be adding to `Tracer` are the global initialization methods.

*An aside on Singleton*

The `Singleton` currently exists solely for the convenience of:

```js
let globalTracer = require('opentracing');  // Both the global instance & free functions
```

vs

```js
let opentracing = require('opentracing');   // Use this for constants and free functions
let globalTracer = opentracing.getGlobalTracer();  // Use this for the global instance
```

Both patterns seem to exist in various JavaScript libraries. The first, one-liner version seems to be a somewhat JavaScript-specific pattern (examples that come to mind are [Handlebars](https://github.com/wycats/handlebars.js) and [Mongoose](http://mongoosejs.com/)). Being explicit about the divide between the Tracer object and free functions/constants might be more clear approach, at the expense of some added verbosity and, unfortunately, an API breaking change.

