### PR TITLE
Fix inverted operation name length test

### DIFF
--- a/src/span.js
+++ b/src/span.js
@@ -61,7 +61,7 @@ export default class Span {
             if (arguments.length !== 1) {
                 throw new Error('Invalid number of arguments');
             }
-            if (typeof name !== 'string' || name.length > 0) {
+            if (typeof name !== 'string' || name.length === 0) {
                 throw new Error('Name must be a string of length > 0');
             }
         }


### PR DESCRIPTION
The operation name length test was incorrect. It was checking that all operation names are zero length not that they are greater than zero length.