### PR TITLE
global tracer call delegation uses wrong this

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+Unreleased
+-------------------
+
+- The `globalTracer` delegate will now correctly call `startSpan`, `inject` and `extract` with the configured global tracer as `this`.
+
+
 0.14.0
 -------------------
 

--- a/src/global_tracer.ts
+++ b/src/global_tracer.ts
@@ -18,17 +18,17 @@ class GlobalTracerDelegate extends Tracer {
 
     startSpan(): any {
         const tracer = _globalTracer || noopTracer;
-        return tracer.startSpan.apply(this, arguments);
+        return tracer.startSpan.apply(tracer, arguments);
     }
 
     inject(): any {
         const tracer = _globalTracer || noopTracer;
-        return tracer.inject.apply(this, arguments);
+        return tracer.inject.apply(tracer, arguments);
     }
 
     extract(): any {
         const tracer = _globalTracer || noopTracer;
-        return tracer.extract.apply(this, arguments);
+        return tracer.extract.apply(tracer, arguments);
     }
 }
 

--- a/src/test/opentracing_api.ts
+++ b/src/test/opentracing_api.ts
@@ -1,6 +1,8 @@
 
 import { expect } from 'chai';
 import * as opentracing from '../index';
+import Span from '../span';
+import { SpanOptions, Tracer } from '../tracer';
 
 export function opentracingAPITests(): void {
     describe('Opentracing API', () => {
@@ -38,6 +40,27 @@ export function opentracingAPITests(): void {
                     expect(opentracing[name]).to.be.a('function');
                 });
             }
+
+            describe('global tracer', () => {
+                const dummySpan = new Span();
+
+                afterEach(() => {
+                  opentracing.initGlobalTracer(new Tracer());
+                });
+
+                it('should use the global tracer', () => {
+                    opentracing.initGlobalTracer(new TestTracer());
+                    const tracer = opentracing.globalTracer();
+                    const span = tracer.startSpan('test');
+                    expect(span).to.equal(dummySpan);
+                });
+
+                class TestTracer extends Tracer {
+                  protected _startSpan(name: string, fields: SpanOptions): Span {
+                      return dummySpan;
+                  }
+                }
+            });
         });
 
         describe('Tracer', () => {


### PR DESCRIPTION
The global tracer delegate uses the delegate as the this context when
calling the configured global tracer. This will break many tracing
implementations. Most notably, this will break all tracing
implementations which subclass the opentracing provided Tracer class.