### PR TITLE
expose span options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ typedoc/
 dist/
 lib/
 .DS_Store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ typedoc/
 dist/
 lib/
 .DS_Store
-.idea

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as Noop from './noop';
 import Reference from './reference';
 import Span from './span';
 import SpanContext from './span_context';
-import Tracer from './tracer';
+import {SpanOptions, Tracer} from './tracer';
 
 export {
     BinaryCarrier,
@@ -12,6 +12,7 @@ export {
     SpanContext,
     Span,
     Tracer,
+    SpanOptions,
     Tags
 };
 

--- a/src/mock_tracer/mock_tracer.ts
+++ b/src/mock_tracer/mock_tracer.ts
@@ -15,7 +15,7 @@ export class MockTracer extends opentracing.Tracer {
     // OpenTracing implementation
     //------------------------------------------------------------------------//
 
-    protected _startSpan(name: string, fields: { [key: string]: any }): MockSpan {
+    protected _startSpan(name: string, fields: opentracing.SpanOptions): MockSpan {
         // _allocSpan is given it's own method so that derived classes can
         // allocate any type of object they want, but not have to duplicate
         // the other common logic in startSpan().
@@ -24,8 +24,8 @@ export class MockTracer extends opentracing.Tracer {
         this._spans.push(span);
 
         if (fields.references) {
-            for (let i = 0; i < fields.references; i++) {
-                span.addReference(fields.references[i]);
+            for (const ref of fields.references) {
+                span.addReference(ref);
             }
         }
 

--- a/src/test/opentracing_api.ts
+++ b/src/test/opentracing_api.ts
@@ -1,8 +1,6 @@
 
 import { expect } from 'chai';
 import * as opentracing from '../index';
-import Span from '../span';
-import { SpanOptions, Tracer } from '../tracer';
 
 export function opentracingAPITests(): void {
     describe('Opentracing API', () => {
@@ -42,10 +40,10 @@ export function opentracingAPITests(): void {
             }
 
             describe('global tracer', () => {
-                const dummySpan = new Span();
+                const dummySpan = new opentracing.Span();
 
                 afterEach(() => {
-                  opentracing.initGlobalTracer(new Tracer());
+                  opentracing.initGlobalTracer(new opentracing.Tracer());
                 });
 
                 it('should use the global tracer', () => {
@@ -55,8 +53,8 @@ export function opentracingAPITests(): void {
                     expect(span).to.equal(dummySpan);
                 });
 
-                class TestTracer extends Tracer {
-                  protected _startSpan(name: string, fields: SpanOptions): Span {
+                class TestTracer extends opentracing.Tracer {
+                  protected _startSpan(name: string, fields: opentracing.SpanOptions): opentracing.Span {
                       return dummySpan;
                   }
                 }


### PR DESCRIPTION
Fixes https://github.com/opentracing/opentracing-javascript/issues/93

The `SpanOptions` type is not exported from the module. This change simply adds an export to the `index.ts` file