### PR TITLE
remove dependency on lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opentracing",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {},
   "devDependencies": {
     "@types/chai": "3.4.35",
-    "@types/lodash": "4.14.61",
     "@types/mocha": "2.2.40",
     "@types/node": "7.0.12",
     "chai": "^3.4.1",
@@ -43,7 +42,6 @@
     "cross-env": "^4.0.0",
     "istanbul": "^0.4.5",
     "json-loader": "^0.5.4",
-    "lodash": "^4.17.4",
     "mocha": "^2.4.5",
     "shelljs": "^0.5.3",
     "source-map-support": "^0.3.3",

--- a/src/mock_tracer/mock_report.ts
+++ b/src/mock_tracer/mock_report.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import * as _ from 'lodash';
 import { DebugInfo, MockSpan } from './mock_span';
 
 /**
@@ -22,7 +21,7 @@ export class MockReport {
 
         this.unfinishedSpans = [];
 
-        _.each(spans, span => {
+        spans.forEach(span => {
             if (span._finishMs === 0) {
                 this.unfinishedSpans.push(span);
             }
@@ -30,7 +29,10 @@ export class MockReport {
             this.spansByUUID[span.uuid()] = span;
             this.debugSpans.push(span.debug());
 
-            _.each(span.tags(), (val, key: string) => {
+            const tags = span.tags();
+
+            Object.keys(tags).forEach((key: string) => {
+                const val = tags[key];
                 this.spansByTag[key] = this.spansByTag[key] || {};
                 this.spansByTag[key][val] = this.spansByTag[key][val] || [];
                 this.spansByTag[key][val].push(span);

--- a/src/mock_tracer/mock_span.ts
+++ b/src/mock_tracer/mock_span.ts
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
-import * as _ from 'lodash';
 import * as opentracing from '../index';
 import Reference from '../reference';
 import MockContext from './mock_context';
@@ -115,7 +114,7 @@ export class MockSpan extends opentracing.Span {
             operation : this._operationName,
             millis    : [this._finishMs - this._startMs, this._startMs, this._finishMs]
         };
-        if (_.size(this._tags)) {
+        if (Object.keys(this._tags).length) {
             obj.tags = this._tags;
         }
         return obj;


### PR DESCRIPTION
This PR removes the dependency on `lodash` since it was causing dependency problems for depending libraries. It was also only used for functionalities that are readily available in pure JS. This problem existed as well when `underscore` was used instead of `lodash` (#75).

Fixes #95 