### PR TITLE
Add support for knowing if a global tracer has been registered

### DIFF
--- a/src/global_tracer.ts
+++ b/src/global_tracer.ts
@@ -2,6 +2,7 @@ import Tracer from './tracer';
 
 const noopTracer = new Tracer();
 let _globalTracer: Tracer | null = null;
+let _isRegistered: boolean = false;
 
 // Allows direct importing/requiring of the global tracer:
 //
@@ -43,6 +44,7 @@ const globalTracerDelegate = new GlobalTracerDelegate();
  */
 export function initGlobalTracer(tracer: Tracer): void {
     _globalTracer = tracer;
+    _isRegistered = true;
 }
 
 /**
@@ -54,4 +56,11 @@ export function globalTracer(): Tracer {
     // give the added convenience of not needing to worry about initialization
     // order.
     return globalTracerDelegate;
+}
+
+/**
+ * Returns true if a global tracer has been registered, otherwise false.
+ */
+export function isGlobalTracerRegistered(): boolean {
+    return _isRegistered;
 }

--- a/src/test/opentracing_api.ts
+++ b/src/test/opentracing_api.ts
@@ -31,7 +31,8 @@ export function opentracingAPITests(): void {
                 'childOf',
                 'followsFrom',
                 'initGlobalTracer',
-                'globalTracer'
+                'globalTracer',
+                'isGlobalTracerRegistered'
             ];
             for (const name of funcs) {
                 it(name + ' should be a function', () => {
@@ -47,7 +48,9 @@ export function opentracingAPITests(): void {
                 });
 
                 it('should use the global tracer', () => {
+                    expect(opentracing.isGlobalTracerRegistered()).to.equal(false);
                     opentracing.initGlobalTracer(new TestTracer());
+                    expect(opentracing.isGlobalTracerRegistered()).to.equal(true);
                     const tracer = opentracing.globalTracer();
                     const span = tracer.startSpan('test');
                     expect(span).to.equal(dummySpan);


### PR DESCRIPTION
Adds support for knowing if a global tracer has been registered via a global variable including tests.

NOTE: Python currently does not prevent you re-registering a global tracer multiple times like C# and Java does.