### PR TITLE
modify example to use ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build": "tsc -p .",
     "watch": "tsc -w -p .",
     "typedoc": "typedoc --out typedoc --tsconfig tsconfig.json --mode file",
-    "example": "node lib/examples/demo/demo.js"
+    "example": "ts-node src/examples/demo/demo.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
found to run 
`npm run example`
that the package.json path was wrong as was the reference to demo.js instead of demo.ts
got it working locally only by using ts-node