### PR TITLE
Fixed #126 - MockTracer._allocSpan is private and can't be overwritten

### DIFF
--- a/src/mock_tracer/mock_tracer.ts
+++ b/src/mock_tracer/mock_tracer.ts
@@ -52,7 +52,7 @@ export class MockTracer extends opentracing.Tracer {
         this._spans = [];
     }
 
-    private _allocSpan(): MockSpan {
+    protected _allocSpan(): MockSpan {
         return new MockSpan(this);
     }
 


### PR DESCRIPTION
changed _allocSpan() to protected