### PR TITLE
Fix circular dependency in mock_context

### DIFF
--- a/src/mock_tracer/mock_context.ts
+++ b/src/mock_tracer/mock_context.ts
@@ -1,11 +1,11 @@
-import * as opentracing from '../index';
+import {SpanContext} from '../span_context';
 import MockSpan from './mock_span';
 
 /**
  * OpenTracing Context implementation designed for use in
  * unit tests.
  */
-export class MockContext extends opentracing.SpanContext {
+export class MockContext extends SpanContext {
 
     //------------------------------------------------------------------------//
     // MockContext-specific


### PR DESCRIPTION
There seems to be a legitimate circular dependency here that causes problems when I build this library using Snowpack:
1. ./index.ts imports ./mock_tracer/index.ts
2. ./mock_tracer/index.ts imports ./mock_tracer/mock_tracer.ts
3. ./mock_tracer/mock_tracer.ts imports ./mock_tracer/mock_context.ts
4. ./mock_tracer/mock_context.ts imports ./index.ts

I _think_ it should be fixed by simply importing `SpanContext` directly rather than importing the full ./index.ts.