### PR TITLE
Fix global tracer delegation

### DIFF
--- a/src/global_tracer.ts
+++ b/src/global_tracer.ts
@@ -16,17 +16,17 @@ let _globalTracer: Tracer | null = null;
 // case where
 class GlobalTracerDelegate extends Tracer {
 
-    startSpan(): any {
+    _startSpan(): any {
         const tracer = _globalTracer || noopTracer;
         return tracer.startSpan.apply(tracer, arguments);
     }
 
-    inject(): any {
+    _inject(): any {
         const tracer = _globalTracer || noopTracer;
         return tracer.inject.apply(tracer, arguments);
     }
 
-    extract(): any {
+    _extract(): any {
         const tracer = _globalTracer || noopTracer;
         return tracer.extract.apply(tracer, arguments);
     }


### PR DESCRIPTION
The base Tracer class wraps the `startSpan`, `inject`, and `extract` functions with some compatibility utilities. Subclasses need to override the `_`-prefixed functions to avoid overriding the wrapper functionality.

With the current implementation, the `childOf` option does not work with LightStep if you use the global tracer function. It tells me that there is an unknown option `childOf`, since the delegate is overriding the wrong functions.