### PR TITLE
Allow past behavior of passing null ctx to Reference ctor

### DIFF
--- a/src/reference.ts
+++ b/src/reference.ts
@@ -61,8 +61,6 @@ export default class Reference {
         // when compiled to Javascript the code would previously still work with nulls.
         // This check ensures backwards compatibility (i.e. no exception) by constructing
         // an invalid reference where _referencedContext is undefined.
-        if (referencedContext != null) {
-            this._referencedContext = toContext(referencedContext);
-        }
+        this._referencedContext = referencedContext ? toContext(referencedContext) : referencedContext;
     }
 }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -56,6 +56,13 @@ export default class Reference {
      */
     constructor(type: string, referencedContext: SpanContext | Span) {
         this._type = type;
-        this._referencedContext = toContext(referencedContext);
+        // See https://github.com/opentracing/opentracing-javascript/issues/172.
+        // Even though the constructor signature does not allow null args in Typescript,
+        // when compiled to Javascript the code would previously still work with nulls.
+        // This check ensures backwards compatibility (i.e. no exception) by constructing
+        // an invalid reference where _referencedContext is undefined.
+        if (referencedContext != null) {
+            this._referencedContext = toContext(referencedContext);
+        }
     }
 }

--- a/src/test/opentracing_api.ts
+++ b/src/test/opentracing_api.ts
@@ -125,10 +125,13 @@ export function opentracingAPITests(): void {
             // Even though the constructor signature does not allow null args in Typescript,
             // when compiled to Javascript the code would previously still work with nulls.
             // This test ensures that such behavior is maintained for backwards compatibility.
-            it('should allow null span context', () => {
-                const spanCtx: any = null;
-                const ref = new opentracing.Reference(opentracing.REFERENCE_CHILD_OF, spanCtx);
-                expect(ref.referencedContext()).to.equal(undefined);
+            it('should allow null and undefined span context', () => {
+                const spanCtx1: any = null;
+                const ref1 = new opentracing.Reference(opentracing.REFERENCE_CHILD_OF, spanCtx1);
+                expect(ref1.referencedContext()).to.equal(null);
+                const spanCtx2: any = undefined;
+                const ref2 = new opentracing.Reference(opentracing.REFERENCE_CHILD_OF, spanCtx2);
+                expect(ref2.referencedContext()).to.equal(undefined);
             });
         });
 

--- a/src/test/opentracing_api.ts
+++ b/src/test/opentracing_api.ts
@@ -126,7 +126,7 @@ export function opentracingAPITests(): void {
             // when compiled to Javascript the code would previously still work with nulls.
             // This test ensures that such behavior is maintained for backwards compatibility.
             it('should allow null span context', () => {
-                let spanCtx: any = null;
+                const spanCtx: any = null;
                 const ref = new opentracing.Reference(opentracing.REFERENCE_CHILD_OF, spanCtx);
                 expect(ref.referencedContext()).to.equal(undefined);
             });

--- a/src/test/opentracing_api.ts
+++ b/src/test/opentracing_api.ts
@@ -120,6 +120,16 @@ export function opentracingAPITests(): void {
                 const ref = new opentracing.Reference(opentracing.REFERENCE_CHILD_OF, ctx);
                 expect(ref.referencedContext()).to.equal(ctx);
             });
+
+            // See https://github.com/opentracing/opentracing-javascript/issues/172.
+            // Even though the constructor signature does not allow null args in Typescript,
+            // when compiled to Javascript the code would previously still work with nulls.
+            // This test ensures that such behavior is maintained for backwards compatibility.
+            it('should allow null span context', () => {
+                let spanCtx: any = null;
+                const ref = new opentracing.Reference(opentracing.REFERENCE_CHILD_OF, spanCtx);
+                expect(ref.referencedContext()).to.equal(undefined);
+            });
         });
 
         describe('BinaryCarrier', () => {


### PR DESCRIPTION
Fix #172